### PR TITLE
feat: support multibyte characters

### DIFF
--- a/lib/rules/no-literal-string.js
+++ b/lib/rules/no-literal-string.js
@@ -62,7 +62,7 @@ module.exports = {
       options: [option]
     } = context;
     const whitelists = [
-      /^[^A-Za-z]+$/, // ignore not-word string
+      /^[0-9!-/:-@[-`{-~]+$/, // ignore not-word string
       ...((option && option.ignore) || [])
     ].map(item => new RegExp(item));
 

--- a/tests/lib/rules/no-literal-string.js
+++ b/tests/lib/rules/no-literal-string.js
@@ -138,6 +138,7 @@ ruleTester.run('no-literal-string', rule, {
       options: [{ markupOnly: true }],
       errors
     },
+    { code: '<div>フー</div>', errors },
     { code: '<DIV foo="bar" />', errors },
     { code: '<DIV foo="bar" />', options: [{ markupOnly: true }], errors },
     { code: '<DIV foo={"bar"} />', options: [{ markupOnly: true }], errors },


### PR DESCRIPTION
Support no literal string even when use multibyte characters.
Multibyte characters were contained ignore list.