### PR TITLE
fix: false negative in ts conditional expression

### DIFF
--- a/lib/rules/no-literal-string.js
+++ b/lib/rules/no-literal-string.js
@@ -226,7 +226,7 @@ module.exports = {
         }
 
         // var a: 'abc' | 'name' = 'abc'
-        if (typeObj.isUnion()) {
+        if (typeObj.isUnion() && node.parent.type !== 'ConditionalExpression') {
           const found = typeObj.types.some(item => {
             if (item.isStringLiteral() && item.value === node.value) {
               return true;

--- a/tests/lib/rules/no-literal-string.js
+++ b/tests/lib/rules/no-literal-string.js
@@ -186,6 +186,7 @@ ruleTester.run('no-literal-string', rule, {
     { code: '<DIV foo={"bar"} />', options: [{ markupOnly: true }], errors },
     { code: '<img src="./image.png" alt="some-image" />', errors },
     { code: '<button aria-label="Close" type="button" />', errors },
+    { code: 'var a = Math.random()>0.5?"hello":123;', errors },
   ],
 });
 
@@ -257,6 +258,10 @@ tsTester.run('no-literal-string', rule, {
       errors,
     },
     { code: "var a: {type: string} = {type: 'bb'}", errors },
+    {
+      code: 'var a = Math.random()>0.5?"hello":123;',
+      errors,
+    },
   ],
 });
 // ────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
We found that in typescript, conditional expression will be treated as union type which makes some case missing in validation.

Examples: 

```ts
const text = Math.random() ? 'hello' : 'world';
// implicit has a union type 'hello' | 'world';
```

I didn't find a proper way to tell the difference, feel free to edit this PR for better solution.