### PR TITLE
Support regex for `ignoreAttribute`

### DIFF
--- a/lib/rules/no-literal-string.js
+++ b/lib/rules/no-literal-string.js
@@ -31,9 +31,7 @@ module.exports = {
           },
           ignoreAttribute: {
             type: 'array',
-            items: {
-              type: 'string',
-            },
+            // string or regexp
           },
           ignoreCallee: {
             type: 'array',
@@ -158,13 +156,15 @@ module.exports = {
       'height',
 
       ...ignoreAttribute,
-    ];
+    ].map(generateFullMatchRegExp);
     function isValidAttrName(name) {
       if (onlyAttribute.length) {
         // only validate those attributes in onlyAttribute option
         return !onlyAttribute.includes(name);
       }
-      return userJSXAttrs.includes(name);
+      return userJSXAttrs.some(item => {
+        return item.test(name);
+      });
     }
 
     // Ignore the Trans component for react-i18next compatibility

--- a/tests/lib/rules/no-literal-string.js
+++ b/tests/lib/rules/no-literal-string.js
@@ -166,6 +166,10 @@ const jsx = {
     { code: '<A style="bar" />' },
     { code: '<button type="button" for="form-id" />' },
     { code: '<DIV foo="bar" />', options: [{ ignoreAttribute: ['foo'] }] },
+    {
+      code: '<DIV fooabc="fooabc" />',
+      options: [{ ignoreAttribute: [/foo.+/] }],
+    },
     { code: '<Trans>foo</Trans>' },
     { code: '<Trans><span>bar</span></Trans>' },
     { code: '<Trans>foo</Trans>', options: [{ ignoreComponent: ['Icon'] }] },
@@ -199,6 +203,11 @@ const jsx = {
     { code: '<DIV foo={"bar"} />', options: [{ markupOnly: true }], errors },
     { code: '<img src="./image.png" alt="some-image" />', errors },
     { code: '<button aria-label="Close" type="button" />', errors },
+    {
+      code: '<DIV foo="fooabc" />',
+      options: [{ ignoreAttribute: [/foo.+/] }],
+      errors,
+    },
   ],
 };
 ruleTester.run('no-literal-string', rule, usual);


### PR DESCRIPTION
- Adds support of `regular expression` for `ignoreAttribute` while being backward compatible 