### PR TITLE
Adding message as config option

### DIFF
--- a/lib/rules/no-literal-string.js
+++ b/lib/rules/no-literal-string.js
@@ -54,6 +54,9 @@ module.exports = {
           markupOnly: {
             type: 'boolean',
           },
+          message: {
+            type: 'string',
+          },
           onlyAttribute: {
             type: 'array',
             items: {
@@ -83,6 +86,7 @@ module.exports = {
           ignoreProperty = [],
           ignoreCallee = [],
           ignore = [],
+          message = 'disallow literal string',
         } = {},
       ],
     } = context;
@@ -91,7 +95,6 @@ module.exports = {
       ...ignore,
     ].map(item => new RegExp(item));
 
-    const message = 'disallow literal string';
     //----------------------------------------------------------------------
     // Helpers
     //----------------------------------------------------------------------

--- a/tests/lib/rules/no-literal-string.js
+++ b/tests/lib/rules/no-literal-string.js
@@ -139,6 +139,11 @@ const usual = {
       code: 'class Form extends Component { property = "Something" };',
       errors,
     },
+    {
+      code: 'export const a = "hello_string";',
+      options: [{ message: 'Some error message' }],
+      errors: [{ message: 'Some error message' }],
+    },
   ],
 };
 
@@ -199,6 +204,11 @@ const jsx = {
     { code: '<DIV foo={"bar"} />', options: [{ markupOnly: true }], errors },
     { code: '<img src="./image.png" alt="some-image" />', errors },
     { code: '<button aria-label="Close" type="button" />', errors },
+    {
+      code: '<div>{"hello world"}</div>',
+      options: [{ markupOnly: true, message: 'Some error message' }],
+      errors: [{ message: 'Some error message' }],
+    },
   ],
 };
 ruleTester.run('no-literal-string', rule, usual);
@@ -279,6 +289,12 @@ tsTester.run('no-literal-string', rule, {
       filename: 'a.tsx',
       options: [{ markupOnly: true }],
       errors,
+    },
+    {
+      code: '<>foo999</>',
+      filename: 'a.tsx',
+      options: [{ markupOnly: true, message: 'Some error message' }],
+      errors: [{ message: 'Some error message' }],
     },
     {
       code: `<button className={styles.btn}>loading</button>`,


### PR DESCRIPTION
Adding error message as a config option to allow users to pass in custom messages for this rule. Message defaults to existing value, 'disallow literal string'

Updated some of the tests to make sure custom message is output.