### PR TITLE
Simplify shouldSkip

### DIFF
--- a/lib/helper/shouldSkip.js
+++ b/lib/helper/shouldSkip.js
@@ -1,13 +1,11 @@
 const matchPatterns = require('./matchPatterns');
 
 module.exports = function shouldSkip({ exclude = [], include = [] }, text) {
-  if (include.length || exclude.length) {
-    if (
-      (!exclude.length || matchPatterns(exclude, text)) &&
-      !matchPatterns(include, text)
-    ) {
-      return true;
-    }
-  }
-  return false;
+  if (!include.length && !exclude.length) return false;
+
+  if (include.length && matchPatterns(include, text)) return false;
+
+  if (exclude.length && !matchPatterns(exclude, text)) return false;
+
+  return true;
 };


### PR DESCRIPTION
Simplify shouldSkip by un-nesting if statements and reordering checks.