### PR TITLE
support eslint 9

### DIFF
--- a/lib/rules/no-literal-string.js
+++ b/lib/rules/no-literal-string.js
@@ -46,7 +46,7 @@ module.exports = {
 
   create(context) {
     // variables should be defined here
-    const { parserServices } = context;
+    const { parserServices } = context.sourceCode;
     const options = _.defaults(
       {},
       context.options[0],
@@ -98,7 +98,8 @@ module.exports = {
     function filterOutJSX(node) {
       if (onlyValidateJSX) {
         const isInsideJSX = context
-          .getAncestors()
+        	.sourceCode
+          .getAncestors(node)
           .some(item => ['JSXElement', 'JSXFragment'].includes(item.type));
 
         if (!isInsideJSX) return true;


### PR DESCRIPTION
`no-literal-string` rule is failing in eslint@9, because few deprecated context methods have been removed (https://github.com/eslint/eslint/commit/ae78ff16558a1a2ca07b2b9cd294157d1bdcce2e). `parserServices` and `getAncestors` methods now live under `context.sourceCode`.