### PR TITLE
docs: fix typo

### DIFF
--- a/docs/rules/no-literal-string.md
+++ b/docs/rules/no-literal-string.md
@@ -36,7 +36,7 @@ type MySchema = {
   };
 } & {
   framework: 'react' | 'vue';
-  mode?: 'jsx-text-only' | 'jsx-only' | 'all' | 'vue-template-ony';
+  mode?: 'jsx-text-only' | 'jsx-only' | 'all' | 'vue-template-only';
   message?: string;
   'should-validate-template'?: boolean;
 };


### PR DESCRIPTION
fix typo mistake in options `mode`