### PR TITLE
feat: add variable name option

### DIFF
--- a/docs/rules/no-literal-string.md
+++ b/docs/rules/no-literal-string.md
@@ -30,7 +30,8 @@ type MySchema = {
     | 'jsx-attributes'
     | 'callees'
     | 'object-properties'
-    | 'class-properties']?: {
+    | 'class-properties'
+    | 'variable-names']?: {
     include?: string[];
     exclude?: string[];
   };
@@ -115,6 +116,15 @@ const message = 'foob';
   class My extends Component {
     displayName = 'MyComponent';
   }
+  ```
+
+- `variable-names` decides whether literal strings are allowed as variables, based on the variable name
+
+  e.g. by default, `UPPER_CASE` constants are excluded, so the value `#f00` is allowed. `label` is not excluded so the value `Red` is not allowed:
+
+  ```js
+  const HEX_CODE = '#f00';
+  const label = 'Red';
   ```
 
 ### Other options

--- a/lib/helper/index.js
+++ b/lib/helper/index.js
@@ -1,9 +1,5 @@
 const { DOM_TAGS, SVG_TAGS } = require('../constants');
 
-function isUpperCase(str) {
-  return /^[A-Z_-]+$/.test(str);
-}
-
 function isNativeDOMTag(str) {
   return DOM_TAGS.includes(str);
 }
@@ -21,7 +17,6 @@ function isAllowedDOMAttr(tag, attr) {
   return false;
 }
 
-exports.isUpperCase = isUpperCase;
 exports.isAllowedDOMAttr = isAllowedDOMAttr;
 exports.generateFullMatchRegExp = require('./generateFullMatchRegExp');
 exports.matchPatterns = require('./matchPatterns');

--- a/lib/options/defaults.js
+++ b/lib/options/defaults.js
@@ -51,6 +51,10 @@ module.exports = {
     include: [],
     exclude: ['displayName'],
   },
+  'variable-names': {
+    include: [],
+    exclude: ['[A-Z_-]+'],
+  },
   message: 'disallow literal string',
   'should-validate-template': false,
 };

--- a/lib/options/schema.json
+++ b/lib/options/schema.json
@@ -51,6 +51,13 @@
         "exclude": { "type": "array" }
       }
     },
+     "variable-names": {
+      "type": "object",
+      "properties": {
+        "include": { "type": "array" },
+        "exclude": { "type": "array" }
+      }
+    },
     "message": { "type": "string" },
     "should-validate-template": { "type": "boolean" }
   }

--- a/lib/rules/no-literal-string.js
+++ b/lib/rules/no-literal-string.js
@@ -6,7 +6,6 @@
 
 const _ = require('lodash');
 const {
-  isUpperCase,
   getNearestAncestor,
   isAllowedDOMAttr,
   shouldSkip,
@@ -292,8 +291,9 @@ module.exports = {
       'ClassProperty:exit': endIndicator,
 
       VariableDeclarator(node) {
-        // allow statements like const A_B = "test"
-        indicatorStack.push(isUpperCase(node.id.name));
+        indicatorStack.push(
+          !!(node.id && shouldSkip(options['variable-names'], node.id.name))
+        );
       },
       'VariableDeclarator:exit': endIndicator,
 

--- a/tests/lib/rules/no-literal-string/variable-names.js
+++ b/tests/lib/rules/no-literal-string/variable-names.js
@@ -1,0 +1,60 @@
+const runTest = require('../../helpers/runTest');
+
+const cases = {
+  valid: [
+    {
+      code: 'const foo = "bar";',
+      options: [
+        {
+          mode: 'all',
+          'variable-names': {
+            include: [],
+            exclude: ['foo'],
+          },
+        },
+      ],
+    },
+    {
+      code: 'const bar = { key: "foo" };',
+      options: [
+        {
+          mode: 'all',
+          'variable-names': {
+            include: ['foo'],
+            exclude: [],
+          },
+        },
+      ],
+    },
+  ],
+  invalid: [
+    {
+      code: 'const foo = "bar";',
+      options: [
+        {
+          mode: 'all',
+          'variable-names': {
+            include: ['foo'],
+            exclude: [],
+          },
+        },
+      ],
+      errors: 1,
+    },
+    {
+      code: 'const bar = { key: "foo" };',
+      options: [
+        {
+          mode: 'all',
+          'variable-names': {
+            include: [],
+            exclude: ['foo'],
+          },
+        },
+      ],
+      errors: 1,
+    },
+  ],
+};
+
+runTest('no-literal-string: variable-names', cases);


### PR DESCRIPTION
Added a option to include/exclude specific variable names from being linted.
Removed the hardcoded isUpperCase and set it as the default option to maintain existing logic for default configs.

Would address #148 
