### PR TITLE
feat: better include and exclude logic that matches documentation

### DIFF
--- a/lib/helper/shouldSkip.js
+++ b/lib/helper/shouldSkip.js
@@ -3,9 +3,10 @@ const matchPatterns = require('./matchPatterns');
 module.exports = function shouldSkip({ exclude = [], include = [] }, text) {
   if (!include.length && !exclude.length) return false;
 
-  if (include.length && matchPatterns(include, text)) return false;
+  const isIncluded = include.length ? matchPatterns(include, text) : true; // include by default
+  const isExcluded = exclude.length ? matchPatterns(exclude, text) : false; // don't exclude by default
 
-  if (exclude.length && !matchPatterns(exclude, text)) return false;
+  if (isIncluded && !isExcluded) return false;
 
   return true;
 };

--- a/tests/lib/rules/no-literal-string/words.js
+++ b/tests/lib/rules/no-literal-string/words.js
@@ -11,11 +11,30 @@ const cases = {
       code: 'const a = "fooabc";',
       options: [{ mode: 'all', words: { exclude: ['^foo.*'] } }],
     },
+    {
+      code: 'const a = "foo";',
+      options: [
+        { mode: 'all', words: { include: ['^foo.*'], exclude: ['^foo'] } },
+      ],
+    },
+    {
+      code: 'const a = "fooabc";',
+      options: [
+        { mode: 'all', words: { include: ['^foo.*'], exclude: ['^foo.*'] } },
+      ],
+    },
   ],
   invalid: [
     {
       code: 'const a = "afoo";',
       options: [{ mode: 'all', words: { exclude: ['^foo'] } }],
+      errors: 1,
+    },
+    {
+      code: 'const a = "fooabc";',
+      options: [
+        { mode: 'all', words: { include: ['^foo.*'], exclude: ['^foo'] } },
+      ],
       errors: 1,
     },
   ],


### PR DESCRIPTION
Updated the include/exclude logic to match what is documented

https://github.com/edvardchen/eslint-plugin-i18next/blob/73be50390602e73d059df4abbf41e1f8b339d330/docs/rules/no-literal-string.md?plain=1#L49-L54

Current logic checks if either condition is satisfied instead of both conditions  being satisfied

## Example
```js
{
  include: ['foo','bar'],
  exclude: ['foo']
}
```
### Current logic 
Validates: `foo`, `bar` and everything NOT `foo` eg: `asdf`,`qwerty` etc

### New logic
Validates: `bar`