### PR TITLE
fix: correct flat config type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,8 +1,8 @@
-import type { ESLint } from 'eslint';
+import type { ESLint, Linter } from 'eslint';
 
 declare const plugin: ESLint.Plugin & {
     configs: {
-        'flat/recommended': ESLint.ConfigData;
+        'flat/recommended': Linter.Config;
         'recommended': ESLint.ConfigData;
     }
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "preversion": "npm run test",
     "postpublish": "git push --follow-tags",
     "test:watch": "npm t -- --watch",
-    "test": "mocha --timeout 50000 tests/lib/rules/no-literal-string/ && pnpm --filter='./examples/*' run lint"
+    "test": "mocha --timeout 50000 tests/lib/rules/no-literal-string/ tests/lib/index.d.ts.test.js && pnpm --filter='./examples/*' run lint"
   },
   "dependencies": {
     "lodash": "^4.17.21",

--- a/tests/lib/index.d.ts.test.js
+++ b/tests/lib/index.d.ts.test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const assert = require('assert');
+const ts = require('typescript');
+const path = require('path');
+
+describe('types: flat recommended config', () => {
+  it('types flat/recommended as Linter.Config', () => {
+    const source = `
+      import i18next = require('${path.resolve(__dirname, '../../lib')}');
+      import type { Linter } from 'eslint';
+
+      const flatConfig: Linter.Config = i18next.configs['flat/recommended'];
+    `;
+
+    const result = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2022,
+        strict: true,
+        moduleResolution: ts.ModuleResolutionKind.Node10,
+        esModuleInterop: true,
+      },
+      reportDiagnostics: true,
+    });
+
+    assert.deepStrictEqual(result.diagnostics || [], []);
+  });
+});


### PR DESCRIPTION
## Summary
- type `flat/recommended` as `Linter.Config` instead of `ESLint.ConfigData`
- keep the legacy `recommended` config typed as `ESLint.ConfigData`
- add a type regression test and include it in the test script

Closes #142