### PR TITLE
chore(deps): swap lodash for native object spread

### DIFF
--- a/lib/rules/no-literal-string.js
+++ b/lib/rules/no-literal-string.js
@@ -4,7 +4,6 @@
  */
 'use strict';
 
-const _ = require('lodash');
 const {
   isUpperCase,
   getNearestAncestor,
@@ -92,11 +91,10 @@ module.exports = {
     // variables should be defined here
     const parserServices =
       context.parserServices || context.sourceCode.parserServices;
-    const options = _.defaults(
-      {},
-      context.options[0],
-      require('../options/defaults')
-    );
+    const options = {
+      ...require('../options/defaults'),
+      ...context.options[0],
+    };
 
     const {
       mode,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "test": "mocha --timeout 50000 tests/lib/rules/no-literal-string/ tests/lib/index.d.ts.test.js && pnpm --filter='./examples/*' run lint"
   },
   "dependencies": {
-    "lodash": "^4.17.21",
     "requireindex": "~1.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      lodash:
-        specifier: ^4.17.21
-        version: 4.18.1
       requireindex:
         specifier: ~1.1.0
         version: 1.1.0


### PR DESCRIPTION
Object spread syntax is available in all versions of node supported by this plugin.